### PR TITLE
Logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ const webauthn = new WebAuthn({
   //   delete: async (id) => {/* return boolean */},
   // },
   rpName: 'Stranger Labs, Inc.',
+  enableLogging: false,
 })
 
 // Mount webauthn endpoints

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "W3C Web Authentication API Relying Party for Node.js and Express",
   "main": "src/Webauthn.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webauthn",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "W3C Web Authentication API Relying Party for Node.js and Express",
   "main": "src/Webauthn.js",
   "scripts": {


### PR DESCRIPTION
This PR adds an option to toggle console logging on and off: `enableLogging`. It closes #10 

- followed code style
- compact scope
- does not affect `console.error`
- packed and tested in example app

For the static methods on the WebAuthn class, I added an argument `enableLogging` but defaulted it to false so any existing implementations won't break.