### PR TITLE
[Example] Add a development workflow

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -42,6 +42,20 @@ const webauthn = new Webauthn({
 $ npm start
 ```
 
+## Development
+
+For an unoptimized development version, first run the server:
+
+```sh
+$ npm run dev-server
+```
+
+Then in another terminal, run the react application in development mode:
+
+```sh
+$ npm run dev-client
+```
+
 ## Contributing
 
 Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.

--- a/example/package.json
+++ b/example/package.json
@@ -2,6 +2,7 @@
   "name": "webauthn-demo",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3001",
   "dependencies": {
     "body-parser": "^1.19.0",
     "bootstrap": "^4.3.1",
@@ -14,7 +15,8 @@
     "webauthn": "^0.1.2"
   },
   "scripts": {
-    "dev": "react-scripts start",
+    "dev-client": "react-scripts start",
+    "dev-server": "PORT=3001 nodemon server.js",
     "server": "nodemon server.js",
     "start": "npm run build && npm run server",
     "build": "react-scripts build",


### PR DESCRIPTION
Add a script to the example app that runs the server in port :3001, and
proxy requests from `react-scripts start` to it. This allows running the
example in an unoptimized mode suitable for development.

Fixes #16