### PR TITLE
Support and default to none attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ user.
   name of that property on the user object.
 - `[store = MemoryAdapter]` - The storage interface for user objects. Defaults
 to an object in memory (for testing only).
+- `[attestation = 'none']` - the [attestation conveyance preference](
+https://w3c.github.io/webauthn/#enum-attestation-convey). Setting this to
+anything other than `'none'` will require attestation and validate it.
 - `[credentialEndpoint = '/register']` - the path of the credential attestation
 challenge endpoint.
 - `[assertionEndpoint = '/login']` - the path of the challenge assertion

--- a/example/README.md
+++ b/example/README.md
@@ -42,6 +42,20 @@ const webauthn = new Webauthn({
 $ npm start
 ```
 
+## Development
+
+For an unoptimized development version, first run the server:
+
+```sh
+$ npm run dev-server
+```
+
+Then in another terminal, run the react application in development mode:
+
+```sh
+$ npm run dev-client
+```
+
 ## Contributing
 
 Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.

--- a/example/package.json
+++ b/example/package.json
@@ -2,6 +2,7 @@
   "name": "webauthn-demo",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3001",
   "dependencies": {
     "body-parser": "^1.19.0",
     "bootstrap": "^4.3.1",
@@ -14,7 +15,8 @@
     "webauthn": "^0.1.2"
   },
   "scripts": {
-    "dev": "react-scripts start",
+    "dev-client": "react-scripts start",
+    "dev-server": "PORT=3001 nodemon server.js",
     "server": "nodemon server.js",
     "start": "npm run build && npm run server",
     "build": "react-scripts build",

--- a/src/AttestationChallengeBuilder.js
+++ b/src/AttestationChallengeBuilder.js
@@ -169,14 +169,7 @@ class AttestationChallengeBuilder {
   }
 
   setAttestationType (attestation = Dictionaries.AttestationConveyancePreference.DIRECT) {
-    const values = Object.values(Dictionaries.AttestationConveyancePreference)
-
-    if (!values.includes(attestation)) {
-      throw new Error(`Invalid AttestationConveyancePreference value. Must be one of "${values.join('", "')}".`)
-    }
-
     this.result.attestation = attestation
-
     return this
   }
 


### PR DESCRIPTION
Add support for 'none' attestation. Consider it valid if the webauthn
config sets the conveyance preference to none.

This change also shuffles some code around to avoid repetition when
verifying the MakeCredential attestation.

Fixes #18 and #11

Depends on #17 