### PR TITLE
[Example] Add logged in page, show errors.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "react-bootstrap": "^1.0.0-beta.8",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.0",
-    "webauthn": "^0.1.2"
+    "webauthn": "file:.."
   },
   "scripts": {
     "dev-client": "react-scripts start",

--- a/example/server.js
+++ b/example/server.js
@@ -62,8 +62,10 @@ const webauthn = new Webauthn({
 app.use('/webauthn', webauthn.initialize())
 
 // Endpoint without passport
-app.get('/secret', webauthn.authenticate(), (req, res) => {
-  res.status(200).json({ status: 'ok', message: `Super secret message for ${req.user.displayName}` })
+app.get('/authenticators', webauthn.authenticate(), async (req, res) => {
+  res.status(200).json([
+      await webauthn.store.get(req.session.username)
+  ].map(user => user.authenticator))
 })
 
 // Debug

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,92 +1,33 @@
+import React from 'react'
+import Login from './Login'
+import User from './User'
+import 'bootstrap/dist/css/bootstrap.min.css'
 
-/**
- * Dependencies
- * @ignore
- */
-import React, { useState } from 'react'
-import { Container, Row, Col, Form, Button } from 'react-bootstrap'
-import Client from 'webauthn/client'
-
-/**
- * Module Dependencies
- * @ignore
- */
-
-/**
- * App
- * @ignore
- */
-function App () {
-  const [name, setName] = useState('')
-  const [username, setUsername] = useState('')
-  const [webauthn] = useState(new Client())
-
-  function onRegister () {
-    webauthn.register({ name, username })
+class App extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      loggedIn: false,
+      user: null,
+    }
   }
 
-  function onLogin () {
-    webauthn.login({ username })
+  login = (user) => {
+    this.setState({
+      loggedIn: true,
+      user,
+    })
   }
 
-  function onLogout () {
-    webauthn.logout()
+  logout = () => {
+    this.setState({loggedIn: false})
   }
 
-  return (
-    <Container>
-      <Row style={{ paddingTop: 80 }}>
-        <Col>
-          <h3>Register</h3>
-          <Form>
-            <Form.Group>
-              <Form.Label>Username</Form.Label>
-              <Form.Control
-                type="text"
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-              ></Form.Control>
-            </Form.Group>
-            <Form.Group>
-              <Form.Label>Name</Form.Label>
-              <Form.Control
-                type="text"
-                value={name}
-                onChange={e => setName(e.target.value)}
-              ></Form.Control>
-              <Form.Text className="text-muted">This name will be displayed publicly.</Form.Text>
-            </Form.Group>
-            <Button variant="primary" onClick={onRegister}>
-              Register
-            </Button>
-          </Form>
-        </Col>
-        <Col>
-          <h3>Login</h3>
-          <Form>
-            <Form.Group>
-              <Form.Label>Username</Form.Label>
-              <Form.Control type="text" value={username} onChange={e => setUsername(e.target.value)}></Form.Control>
-            </Form.Group>
-            <Button variant="primary" onClick={onLogin}>
-              Login
-            </Button>
-          </Form>
-        </Col>
-      </Row>
-      <Row style={{ paddingTop: 80 }}>
-        <Col>
-          <Button variant="outline-primary" block onClick={onLogout}>
-            Logout
-          </Button>
-        </Col>
-      </Row>
-    </Container>
-  )
+  render () {
+    return this.state.loggedIn ?
+        <User onLogout={this.logout} user={this.state.user} />
+      : <Login onLogin={this.login} />
+  }
 }
 
-/**
- * Exports
- * @ignore
- */
 export default App;

--- a/example/src/AuthenticatorCard.js
+++ b/example/src/AuthenticatorCard.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Card } from 'react-bootstrap'
+import 'bootstrap/dist/css/bootstrap.min.css'
+
+class AuthenticatorCard extends React.Component {
+  render () {
+    return (
+      <Card style={{ width: '32rem' }}>
+        <Card.Body>
+          <Card.Title>{this.props.authenticator.credID}</Card.Title>
+          <Card.Text>
+            <p><strong>Format: </strong> {this.props.authenticator.fmt}</p>
+            <p><strong>Counter: </strong> {this.props.authenticator.counter}</p>
+            <p><strong>Public key: </strong> {this.props.authenticator.publicKey}</p>
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    )
+  }
+}
+
+export default AuthenticatorCard;

--- a/example/src/Login.js
+++ b/example/src/Login.js
@@ -1,0 +1,112 @@
+
+/**
+ * Dependencies
+ * @ignore
+ */
+import React, { useState } from 'react'
+import { Container, Row, Col, Form, Button, Alert } from 'react-bootstrap'
+import Client from 'webauthn/client'
+
+/**
+ * Module Dependencies
+ * @ignore
+ */
+
+/**
+ * Login
+ * @ignore
+ */
+function Login (props) {
+  const [name, setName] = useState('')
+  const [username, setUsername] = useState('')
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [webauthn] = useState(new Client())
+
+  function onRegister () {
+    if (username === "") {
+      setError('Please enter a username')
+      return
+    }
+    webauthn.register({ name, username }).then(response => {
+      console.log('Register response: ', response)
+      setSuccess('Registration successful. Try logging in.')
+    }).catch(error => {
+      setError(error.message)
+    })
+  }
+
+  function onLogin () {
+    if (username === "") {
+      setError('Please enter a username')
+      return
+    }
+    webauthn.login({ username }).then(response => {
+      console.log('Login response: ', response);
+      if (response && response.status === "ok")
+        props.onLogin({
+          username,
+        });
+    }).catch(error => setError(error.message))
+  }
+
+  return (
+    <Container>
+      <Row style={{ paddingTop: 80 }}>
+        <Col>
+          {error && <Alert variant="danger" dismissible onClose={() => setError('')}>
+            {error}
+          </Alert>}
+          {success && <Alert variant="success" dismissible onClose={() => setSuccess('')}>
+            {success}
+          </Alert>}
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <h3>Register</h3>
+          <Form>
+            <Form.Group>
+              <Form.Label>Username</Form.Label>
+              <Form.Control
+                type="text"
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+              ></Form.Control>
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Name</Form.Label>
+              <Form.Control
+                type="text"
+                value={name}
+                onChange={e => setName(e.target.value)}
+              ></Form.Control>
+              <Form.Text className="text-muted">This name will be displayed publicly.</Form.Text>
+            </Form.Group>
+            <Button variant="primary" onClick={onRegister}>
+              Register
+            </Button>
+          </Form>
+        </Col>
+        <Col>
+          <h3>Login</h3>
+          <Form>
+            <Form.Group>
+              <Form.Label>Username</Form.Label>
+              <Form.Control type="text" value={username} onChange={e => setUsername(e.target.value)}></Form.Control>
+            </Form.Group>
+            <Button variant="primary" onClick={onLogin}>
+              Login
+            </Button>
+          </Form>
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+/**
+ * Exports
+ * @ignore
+ */
+export default Login;

--- a/example/src/User.js
+++ b/example/src/User.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Container, Row, Col, Button } from 'react-bootstrap'
+import AuthenticatorCard from './AuthenticatorCard'
+import Client from 'webauthn/client'
+import 'bootstrap/dist/css/bootstrap.min.css'
+
+class User extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      authenticators: []
+    }
+
+    fetch('authenticators', {
+      method: 'GET',
+      credentials: 'include',
+    }).then(response => {
+      if (response.status !== 200) {
+        console.error(response.message)
+        return
+      }
+      return response.json()
+    }).then(authenticators => {
+      this.setState({ authenticators })
+    })
+  }
+
+  logout = () => {
+    (new Client()).logout().then(() => this.props.onLogout())
+  }
+
+  render () {
+    return (
+      <Container>
+        <Row style={{ paddingTop: 80}}>
+          <Col>
+            <h2>Welcome {this.props.user.username}</h2>
+            <h3>Your authenticators:</h3>
+          </Col>
+          <Col className="text-right">
+            <Button variant="primary" onClick={this.logout}>Log Out</Button>
+          </Col>
+        </Row>
+        {this.state.authenticators.map(authenticator => <Row key={authenticator.credID}>
+          <Col><AuthenticatorCard authenticator={authenticator} /></Col>
+        </Row>)}
+      </Container>
+    )
+  }
+}
+
+export default User;


### PR DESCRIPTION
This adds a page that is visible when the user has logged in and calls an endpoint that's protected by webauthn.