### PR TITLE
Update repo references from GitLab to GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://gitlab.com/strangerlabs/webauthn/issues"
+    "url": "https://github.com/strangerlabs/webauthn/issues"
   },
-  "homepage": "https://gitlab.com/strangerlabs/webauthn",
+  "homepage": "https://github.com/strangerlabs/webauthn",
   "dependencies": {
     "@fidm/x509": "^1.2.1",
     "base64url": "^3.0.1",


### PR DESCRIPTION
I've only just taken a look at the package, but on the NPM page it shows a links to a non-existant GitLab repo, rather than this GitHub repo. The following references in need to be updated:

The package homepage https://github.com/strangerlabs/webauthn/blob/d8d63d224c022d18fcca3bc51cf9e388e1668d45/package.json#L46 and the bugs URL https://github.com/strangerlabs/webauthn/blob/d8d63d224c022d18fcca3bc51cf9e388e1668d45/package.json#L44